### PR TITLE
The old sbt-pgp 0.8.3 is no longer supported in sbt 0.13.5+.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.4.0")
 


### PR DESCRIPTION
Per http://www.scala-sbt.org/sbt-pgp/ the version of sbt-pgp should be 1.0.0 since `build.properties` specifies sbt 0.13.11.

Not sure how this works right now since I can't get sbt 0.13.11 to even load the project without a class-cast-exception on the old sbt-pgp plugin.
