### PR TITLE
Updated to use json4s-jackson backend.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val jwt: Project = (project in file("jwt"))
   .settings(
     name := "jwt",
     libraryDependencies ++= Seq(
-      "org.json4s" %% "json4s-native" % "3.3.0",
+      "org.json4s" %% "json4s-jackson" % "3.3.0",
       scalaTest
     )
   ) dependsOn(core)

--- a/jwt/src/main/scala/com/softwaremill/session/JwtSessionEncoder.scala
+++ b/jwt/src/main/scala/com/softwaremill/session/JwtSessionEncoder.scala
@@ -3,8 +3,7 @@ package com.softwaremill.session
 import javax.xml.bind.DatatypeConverter
 
 import org.json4s._
-import org.json4s.native.JsonMethods._
-
+import org.json4s.jackson.JsonMethods._
 import scala.util.Try
 
 class JwtSessionEncoder[T](implicit serializer: SessionSerializer[T, JValue], formats: Formats = DefaultFormats)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.4.0")
 


### PR DESCRIPTION
The json4s-native backend is broken in several ways. It encodes all JSON, which is allowed, but non-standard since JSON is required to be UTF-8 encoded, and it fails to properly escape UTF-8 control characters, which can often show up in localized strings. See: json4s/json4s#333 (comment)

The breakage introduced in json4s 3.3.x was rolled back and corrected in https://github.com/json4s/json4s/pull/339 as part of 3.4.0-SNAPSHOT, but that hasn't been published yet. Using the Jackson backend works around this because the breakage is limited to the native implementation.

This depends on the previous sbt-pgp fix PR.
