### PR TITLE
Downgrade scalacheck to version that maintains binary compatibility with scalatest.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val core: Project = (project in file("core"))
       "com.typesafe.akka" %% "akka-http-core" % akkaVersion,
       "com.typesafe.akka" %% "akka-http-experimental" % akkaVersion,
       "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion % "test",
-      "org.scalacheck" %% "scalacheck" % "1.13.0" % "test",
+      "org.scalacheck" %% "scalacheck" % "1.12.5" % "test",
       scalaTest
     )
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.4.0")
 


### PR DESCRIPTION
scalacheck 1.13.x is not compatible with scalatest 2.2.6. See: https://github.com/rickynils/scalacheck/issues/217

This dependency may cause breakages in downstream projects with `classifier tests` dependencies. Reverted to a compatible version of scalacheck. If someone wants to use `1.13.x` in their project, maybe they aren't using scalatest, or maybe they just haven't run into the `IncompatibleClassChangeError`, then more power to them, this won't change anything for them, but for people who are seeing the error and have taken care to use the compatible version of scalacheck, this change will avoid reintroducing the breakage for them.
