### PR TITLE
do not set session when it expired

### DIFF
--- a/core/src/main/scala/com/softwaremill/session/SessionDirectives.scala
+++ b/core/src/main/scala/com/softwaremill/session/SessionDirectives.scala
@@ -172,7 +172,7 @@ trait RefreshableSessionDirectives { this: OneOffSessionDirectives =>
             onSuccess(sc.refreshTokenManager.sessionFromValue(v))
               .flatMap {
                 case s @ SessionResult.CreatedFromToken(session) =>
-                  setRefreshableSession(sc, setSt, session) & provide(s: SessionResult[T])
+                  setRefreshToken(sc, setSt, session) & provide(s: SessionResult[T])
                 case s => provide(s)
               }
         }

--- a/core/src/main/scala/com/softwaremill/session/SessionDirectives.scala
+++ b/core/src/main/scala/com/softwaremill/session/SessionDirectives.scala
@@ -172,7 +172,7 @@ trait RefreshableSessionDirectives { this: OneOffSessionDirectives =>
             onSuccess(sc.refreshTokenManager.sessionFromValue(v))
               .flatMap {
                 case s @ SessionResult.CreatedFromToken(session) =>
-                  setRefreshToken(sc, setSt, session) & provide(s: SessionResult[T])
+                  setRefreshableSession(sc, setSt, session) & provide(s: SessionResult[T])
                 case s => provide(s)
               }
         }

--- a/core/src/test/scala/com/softwaremill/session/RefreshableTest.scala
+++ b/core/src/test/scala/com/softwaremill/session/RefreshableTest.scala
@@ -106,6 +106,23 @@ class RefreshableTest extends FlatSpec with ScalatestRouteTest with Matchers wit
       }
     }
 
+    p should "set a new session after the session is re-created" in {
+      Get("/set") ~> routes ~> check {
+        val Some(token1) = using.getRefreshToken
+        val session1 = using.getSession
+        session1 should be('defined)
+
+        Get("/getOpt") ~>
+          addHeader(using.setRefreshTokenHeader(token1)) ~>
+          routes ~>
+          check {
+            val session2 = using.getSession
+            session2 should be('defined)
+            session2 should not be (session1)
+          }
+      }
+    }
+
     p should "read an optional session when none is set" in {
       Get("/getOpt") ~> routes ~> check {
         responseAs[String] should be("None")


### PR DESCRIPTION
When running the "should touch the session, keeping the refresh token token intact" test, the last Get request will result in two _sessiondata cookies or Set-Authorization headers. That's not a tragedy, since the session data is the same (value as well as the expiring timestamp).
The reason for this is how `SessionDirectives.touchRequiredSession` works.
It calls, `requiredSession and `setOneOffSessionSameTransport`. The second function sets the session as expected. The first one however sets the session in a particular case, when it expired and a refresh token is provided to refresh the session. This PR fixes the issues by only setting a new refresh token without setting the session data cookie/header a second time.