### PR TITLE
Token migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,20 @@ For `akka-http` version `10.0.3`:
 libraryDependencies += "com.softwaremill.akka-http-session" %% "core" % "0.5.3"
 libraryDependencies += "com.softwaremill.akka-http-session" %% "jwt"  % "0.5.3" // optional
 ````
+
+## Updating
+
+Certain releases changed the client token encoding/serialization. In those cases, it's important to enable the appropriate
+token migrations, otherwise existing client sessions will be invalid (and your users will be logged out).
+
+When updating from a version before 0.5.3, set `akka-http-session.token-migration.v0-5-3.enabled = true`.
+
+When updating from a version before 0.5.2, set `akka-http-session.token-migration.v0-5-2.enabled = true`.
+
+Note that when updating through multiple releases, be sure to enable all the appropriate migrations.
+
+For versions prior to 0.5.0, no migration path is provided. However, you can implement your own encoders/serializers
+to support migrating from whatever version you are using.
+
+Since token changes may be security related, migrations should be enabled for the shortest period of time
+after which the vast majority of client tokens have been migrated.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -39,4 +39,13 @@ akka.http.session {
     max-age = 30 days
     remove-used-token-after = 5 seconds
   }
+
+  token-migration {
+    v0-5-2 {
+      enabled = false
+    }
+    v0-5-3 {
+      enabled = false
+    }
+  }
 }

--- a/core/src/main/scala/com/softwaremill/session/Crypto.scala
+++ b/core/src/main/scala/com/softwaremill/session/Crypto.scala
@@ -5,6 +5,7 @@ import java.util
 import java.util.Base64
 import javax.crypto.{Cipher, Mac}
 import javax.crypto.spec.SecretKeySpec
+import javax.xml.bind.DatatypeConverter
 
 import com.softwaremill.session.SessionUtil._
 
@@ -21,6 +22,13 @@ object Crypto {
     val mac = Mac.getInstance("HmacSHA256")
     mac.init(new SecretKeySpec(key, "HmacSHA256"))
     Base64.getUrlEncoder().withoutPadding().encodeToString(mac.doFinal(message.getBytes("utf-8")))
+  }
+
+  def sign_HmacSHA256_base64_v0_5_2(message: String, secret: String): String = {
+    val key = secret.getBytes("UTF-8")
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(new SecretKeySpec(key, "HmacSHA256"))
+    DatatypeConverter.printBase64Binary(mac.doFinal(message.getBytes("utf-8")))
   }
 
   def encrypt_AES(value: String, secret: String): String = {

--- a/core/src/main/scala/com/softwaremill/session/SessionConfig.scala
+++ b/core/src/main/scala/com/softwaremill/session/SessionConfig.scala
@@ -46,7 +46,12 @@ case class SessionConfig(
    * When a refresh token is used to log in, a new one is generated. The old one should be deleted with a delay,
    * to properly serve concurrent requests using the old token.
    */
-  removeUsedRefreshTokenAfter: Long) {
+  removeUsedRefreshTokenAfter: Long,
+  /**
+   * Allow migrating tokens created with prior versions of this library.
+   */
+  tokenMigrationV0_5_2Enabled: Boolean,
+  tokenMigrationV0_5_3Enabled: Boolean) {
   require(serverSecret.length >= 64, "Server secret must be at least 64 characters long!")
 }
 
@@ -66,6 +71,7 @@ object SessionConfig {
     val scopedConfig = config.getConfig("akka.http.session")
     val csrfConfig = scopedConfig.getConfig("csrf")
     val refreshTokenConfig = scopedConfig.getConfig("refresh-token")
+    val tokenMigrationConfig = scopedConfig.getConfig("token-migration")
 
     SessionConfig(
       serverSecret = scopedConfig.getString("server-secret"),
@@ -97,7 +103,9 @@ object SessionConfig {
         sendToClientHeaderName = refreshTokenConfig.getString("header.send-to-client-name"),
         getFromClientHeaderName = refreshTokenConfig.getString("header.get-from-client-name")),
       refreshTokenMaxAgeSeconds = refreshTokenConfig.getDuration("max-age", TimeUnit.SECONDS),
-      removeUsedRefreshTokenAfter = refreshTokenConfig.getDuration("remove-used-token-after", TimeUnit.SECONDS))
+      removeUsedRefreshTokenAfter = refreshTokenConfig.getDuration("remove-used-token-after", TimeUnit.SECONDS),
+      tokenMigrationV0_5_2Enabled = tokenMigrationConfig.getBoolean("v0-5-2.enabled"),
+      tokenMigrationV0_5_3Enabled = tokenMigrationConfig.getBoolean("v0-5-3.enabled"))
   }
 
   /**

--- a/core/src/main/scala/com/softwaremill/session/SessionManager.scala
+++ b/core/src/main/scala/com/softwaremill/session/SessionManager.scala
@@ -66,6 +66,9 @@ trait ClientSessionManager[T] {
       else if (!dr.signatureMatches) {
         SessionResult.Corrupt(new RuntimeException("Corrupt signature"))
       }
+      else if (dr.isLegacy) {
+        SessionResult.DecodedLegacy(dr.t)
+      }
       else {
         SessionResult.Decoded(dr.t)
       }
@@ -188,6 +191,7 @@ object SessionResult {
   }
 
   case class Decoded[T](session: T) extends SessionResult[T] with SessionValue[T]
+  case class DecodedLegacy[T](session: T) extends SessionResult[T] with SessionValue[T]
   case class CreatedFromToken[T](session: T) extends SessionResult[T] with SessionValue[T]
 
   case object NoSession extends SessionResult[Nothing] with NoSessionValue[Nothing]

--- a/core/src/test/scala/com/softwaremill/session/Legacy.scala
+++ b/core/src/test/scala/com/softwaremill/session/Legacy.scala
@@ -1,0 +1,48 @@
+package com.softwaremill.session
+
+import scala.util.Try
+
+object Legacy {
+  class MultiValueSessionSerializerV0_5_2[T](toMap: T => Map[String, String], fromMap: Map[String, String] => Try[T])
+      extends SessionSerializer[T, String] {
+
+    import SessionSerializer._
+
+    override def serialize(t: T) = toMap(t)
+      .map { case (k, v) => urlEncode(k) + "=" + urlEncode(v) }
+      .mkString("&")
+
+    override def deserialize(s: String) = {
+      Try {
+        if (s == "") Map.empty[String, String]
+        else {
+          s
+            .split("&")
+            .map(_.split("=", 2))
+            .map(p => urlDecode(p(0)) -> urlDecode(p(1)))
+            .toMap
+        }
+      }.flatMap(fromMap)
+    }
+  }
+
+  def encodeV0_5_1(data: Map[String, String], nowMillis: Long, config: SessionConfig): String = {
+    val serializer = new MultiValueSessionSerializerV0_5_2[Map[String, String]](identity, Try(_))
+    val serialized = "x" + serializer.serialize(data)
+
+    val withExpiry = config.sessionMaxAgeSeconds.fold(serialized) { maxAge =>
+      val expiry = nowMillis + maxAge * 1000L
+      s"$expiry-$serialized"
+    }
+
+    val encrypted = if (config.sessionEncryptData) Crypto.encrypt_AES(withExpiry, config.serverSecret) else withExpiry
+
+    s"${Crypto.sign_HmacSHA1_hex(serialized, config.serverSecret)}-$encrypted"
+  }
+
+  def encodeV0_5_2(data: Map[String, String], nowMillis: Long, config: SessionConfig): String = {
+    val serializer = new MultiValueSessionSerializerV0_5_2[Map[String, String]](identity, Try(_))
+    val encoder = new BasicSessionEncoder[Map[String, String]]()(serializer)
+    encoder.encode(data, nowMillis, config)
+  }
+}

--- a/core/src/test/scala/com/softwaremill/session/OneOffTest.scala
+++ b/core/src/test/scala/com/softwaremill/session/OneOffTest.scala
@@ -166,5 +166,55 @@ class OneOffTest extends FlatSpec with ScalatestRouteTest with Matchers with Mul
           }
       }
     }
+
+    p should "reject v0.5.1 session without migration config" in {
+      Get("/set") ~> routes ~> check {
+        val data = Map("k1" -> "v1")
+        val now = System.currentTimeMillis()
+        val legacySession = Legacy.encodeV0_5_1(data, now, sessionConfig)
+
+        Get("/getReq") ~> addHeader(using.setSessionHeader(legacySession)) ~> routes ~> check {
+          rejection should be(AuthorizationFailedRejection)
+        }
+      }
+    }
+
+    p should "migrate v0.5.1 session with migration config" in {
+      Get("/set") ~> routes ~> check {
+        val data = Map("k1" -> "v1")
+        val now = System.currentTimeMillis()
+        val legacySession = Legacy.encodeV0_5_1(data, now, sessionConfig)
+
+        Get("/getReq") ~> addHeader(using.setSessionHeader(legacySession)) ~> routes(manager_tokenMigrationFromV0_5_1) ~> check {
+          using.getSession should be ('defined)
+          responseAs[String] should be(data.toString)
+        }
+      }
+    }
+
+    p should "reject v0.5.2 session without migration config" in {
+      Get("/set") ~> routes ~> check {
+        val data = Map("k1" -> "v1")
+        val now = System.currentTimeMillis()
+        val legacySession = Legacy.encodeV0_5_2(data, now, sessionConfig)
+
+        Get("/getReq") ~> addHeader(using.setSessionHeader(legacySession)) ~> routes ~> check {
+          rejection should be(AuthorizationFailedRejection)
+        }
+      }
+    }
+
+    p should "migrate v0.5.2 session with migration config" in {
+      Get("/set") ~> routes ~> check {
+        val data = Map("k1" -> "v1")
+        val now = System.currentTimeMillis()
+        val legacySession = Legacy.encodeV0_5_2(data, now, sessionConfig)
+
+        Get("/getReq") ~> addHeader(using.setSessionHeader(legacySession)) ~> routes(manager_tokenMigrationFromV0_5_2) ~> check {
+          using.getSession should be ('defined)
+          responseAs[String] should be(data.toString)
+        }
+      }
+    }
   }
 }

--- a/core/src/test/scala/com/softwaremill/session/TestData.scala
+++ b/core/src/test/scala/com/softwaremill/session/TestData.scala
@@ -16,4 +16,10 @@ object TestData {
   val manager_expires60_fixedTime_plus70s = new SessionManager[Map[String, String]](sessionConfig_expires60) {
     override def nowMillis = (3028L + 70L) * 1000L
   }
+
+  val sessionConfig_tokenMigrationFromV0_5_1 = sessionConfig.copy(tokenMigrationV0_5_2Enabled = true, tokenMigrationV0_5_3Enabled = true)
+  val manager_tokenMigrationFromV0_5_1 = new SessionManager[Map[String, String]](sessionConfig_tokenMigrationFromV0_5_1)
+
+  val sessionConfig_tokenMigrationFromV0_5_2 = sessionConfig.copy(tokenMigrationV0_5_3Enabled = true)
+  val manager_tokenMigrationFromV0_5_2 = new SessionManager[Map[String, String]](sessionConfig_tokenMigrationFromV0_5_2)
 }

--- a/example/src/main/scala/com/softwaremill/example/session/VariousSessionsScala.scala
+++ b/example/src/main/scala/com/softwaremill/example/session/VariousSessionsScala.scala
@@ -53,11 +53,14 @@ object VariousSessionsScala extends App with StrictLogging {
       path("detail") {
         get {
           // type: SessionResult[Long] (SessionResult[T])
-          // which can be: Decoded, CreatedFromToken, Expired, Corrupt, NoSession
+          // which can be: Decoded, DecodedLegacy, CreatedFromToken, Expired, Corrupt, NoSession
           session(oneOff, usingCookies) { sessionResult =>
             sessionResult match {
               case Decoded(session) => complete {
                 "decoded"
+              }
+              case DecodedLegacy(session) => complete {
+                "decoded legacy"
               }
               case CreatedFromToken(session) => complete {
                 "created from token"

--- a/jwt/src/main/scala/com/softwaremill/session/JwtSessionEncoder.scala
+++ b/jwt/src/main/scala/com/softwaremill/session/JwtSessionEncoder.scala
@@ -1,7 +1,7 @@
 package com.softwaremill.session
 
 import java.util.Base64
-
+import javax.xml.bind.DatatypeConverter
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import scala.util.Try
@@ -18,18 +18,53 @@ class JwtSessionEncoder[T](implicit serializer: SessionSerializer[T, JValue], fo
     s"$base.$signature"
   }
 
+  // Legacy encoder function for testing migrations.
+  def encodeV0_5_2(t: T, nowMillis: Long, config: SessionConfig) = {
+    val h = encode(createHeader)
+    val p = encode(createPayload(t, nowMillis, config))
+    val base = s"$h.$p"
+    val signature = Crypto.sign_HmacSHA256_base64_v0_5_2(base, config.serverSecret)
+
+    s"$base.$signature"
+  }
+
   override def decode(s: String, config: SessionConfig) = Try {
     val sCleaned = if (s.startsWith("Bearer")) s.substring(7).trim else s
     val List(h, p, signature) = sCleaned.split("\\.").toList
 
-    val signatureMatches = SessionUtil.constantTimeEquals(
-      signature,
-      Crypto.sign_HmacSHA256_base64(s"$h.$p", config.serverSecret))
+    val (decodedValue, decodedLegacy) = {
+      val decodedValue = decode(p)
+
+      if (decodedValue.isFailure && config.tokenMigrationV0_5_3Enabled) {
+        // Try decoding assuming pre-v0.5.3.
+        (decodeV0_5_2(p), true)
+      }
+      else {
+        (decodedValue, false)
+      }
+    }
 
     for {
-      jv <- decode(p)
+      jv <- decodedValue
       (t, exp) <- extractPayload(jv, config)
-    } yield DecodeResult(t, exp, signatureMatches, isLegacy = false)
+    } yield {
+      val signatureMatches = SessionUtil.constantTimeEquals(
+        signature,
+        Crypto.sign_HmacSHA256_base64(s"$h.$p", config.serverSecret))
+
+      if (!signatureMatches && config.tokenMigrationV0_5_3Enabled) {
+        // Try signature check assuming pre-v0.5.3.
+        val signatureMatchesLegacy = SessionUtil.constantTimeEquals(
+          signature,
+          Crypto.sign_HmacSHA256_base64_v0_5_2(s"$h.$p", config.serverSecret))
+
+        val isLegacy = signatureMatchesLegacy || decodedLegacy
+        DecodeResult(t, exp, signatureMatchesLegacy, isLegacy = isLegacy)
+      }
+      else {
+        DecodeResult(t, exp, signatureMatches, isLegacy = decodedLegacy)
+      }
+    }
   }.flatten
 
   protected def createHeader: JValue = JObject(
@@ -76,5 +111,8 @@ class JwtSessionEncoder[T](implicit serializer: SessionSerializer[T, JValue], fo
   protected def encode(jv: JValue): String = Base64.getUrlEncoder().withoutPadding().encodeToString(compact(render(jv)).getBytes("utf-8"))
   protected def decode(s: String): Try[JValue] = Try {
     parse(new String(Base64.getUrlDecoder().decode(s), "utf-8"))
+  }
+  protected def decodeV0_5_2(s: String): Try[JValue] = Try {
+    parse(new String(DatatypeConverter.parseBase64Binary(s), "utf-8"))
   }
 }

--- a/jwt/src/main/scala/com/softwaremill/session/JwtSessionEncoder.scala
+++ b/jwt/src/main/scala/com/softwaremill/session/JwtSessionEncoder.scala
@@ -29,7 +29,7 @@ class JwtSessionEncoder[T](implicit serializer: SessionSerializer[T, JValue], fo
     for {
       jv <- decode(p)
       (t, exp) <- extractPayload(jv, config)
-    } yield DecodeResult(t, exp, signatureMatches)
+    } yield DecodeResult(t, exp, signatureMatches, isLegacy = false)
   }.flatten
 
   protected def createHeader: JValue = JObject(


### PR DESCRIPTION
Introduces token migration for client sessions created with older versions of this library.

Upgrading the library might result in previous session tokens failing to decode, resulting in users being logged out. Now there are configuration settings to enable token migration to the current version.

I've only considered v0.5.0 -> v0.5.3 (current):
- No token changes were made from v0.5.0 -> v0.5.1. 
- On v0.5.2, the signature changed: https://github.com/softwaremill/akka-http-session/compare/c143365cf25d78f1a80fd2f71273a95b6c2ad9a5...release-0.5.2
- On v0.5.3 the multi-value serializer changed:  https://github.com/softwaremill/akka-http-session/compare/release-0.5.2...6f67a92d9e85a2a210d0afc19fd3cde06623b821

These are the added configs:
```
akka.http.session {
  ...
  token-migration {
    v0-5-2 {
      enabled = false
    }
    v0-5-3 {
      enabled = false
    }
  }
}
```
If you're upgrading from v0.5.1 to v0.5.3 (current), you should enable migrations for both v0.5.2 and v0.5.3. If you're upgrading from v0.5.2, you only need to enable the v0.5.3 migration.