### PR TITLE
README: Correct expected format of a private RSA key

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ In order to start using RSA algorithm you have to configure `akka.http.session.j
 akka.http.session {
   jws {
     alg = "RS256"
-    rsa-private-key = "<your private PKCS1-v1_5 key goes here>"
+    rsa-private-key = "<your private PKCS#8 key goes here>"
   }
 }
 ````


### PR DESCRIPTION
Fix typo in README.md - `akka.http.session.jws.rsa-private-key` value placeholder contained an incorect information that RSA key must be in a `PKCS#1` format (should be `PKCS#8`)