### PR TITLE
Make 'alg' JWT header's parameter follow the config

### DIFF
--- a/core/src/main/scala/com/softwaremill/session/JwsAlgorithm.scala
+++ b/core/src/main/scala/com/softwaremill/session/JwsAlgorithm.scala
@@ -10,12 +10,15 @@ import com.typesafe.config.Config
 import scala.util.{Failure, Success, Try}
 
 sealed trait JwsAlgorithm {
+  def value: String
   def sign(message: String): String
 }
 
 object JwsAlgorithm {
 
   case class Rsa(privateKey: PrivateKey) extends JwsAlgorithm {
+
+    override val value: String = "RS256"
 
     override def sign(message: String): String = {
       val privateSignature: Signature = Signature.getInstance("SHA256withRSA")
@@ -56,6 +59,7 @@ object JwsAlgorithm {
   }
 
   case class HmacSHA256(serverSecret: String) extends JwsAlgorithm {
+    override val value: String = "HS256"
     override def sign(message: String): String = Crypto.sign_HmacSHA256_base64(message, serverSecret)
   }
 


### PR DESCRIPTION
This PR fixes a bug with issuing JWT tokens with `alg` header always set to `HS256` (regardless of the currently applied configuration).

Since our library does not care about the header's `alg` value when checking Json Web Signatures, this issue did not appear as long as you either stay with HS256 algorithm or do not perform any JWS verification outside of your app.