### PR TITLE
Fix encoding (Base64 URL) for RSA-based signatures

### DIFF
--- a/core/src/main/scala/com/softwaremill/session/Crypto.scala
+++ b/core/src/main/scala/com/softwaremill/session/Crypto.scala
@@ -2,11 +2,10 @@ package com.softwaremill.session
 
 import java.security.MessageDigest
 import java.util
-import java.util.Base64
-import javax.crypto.{Cipher, Mac}
-import javax.crypto.spec.SecretKeySpec
 
 import com.softwaremill.session.SessionUtil._
+import javax.crypto.spec.SecretKeySpec
+import javax.crypto.{Cipher, Mac}
 
 object Crypto {
   def sign_HmacSHA1_hex(message: String, secret: String): String = {
@@ -14,13 +13,6 @@ object Crypto {
     val mac = Mac.getInstance("HmacSHA1")
     mac.init(new SecretKeySpec(key, "HmacSHA1"))
     toHexString(mac.doFinal(message.getBytes("utf-8")))
-  }
-
-  def sign_HmacSHA256_base64(message: String, secret: String): String = {
-    val key = secret.getBytes("UTF-8")
-    val mac = Mac.getInstance("HmacSHA256")
-    mac.init(new SecretKeySpec(key, "HmacSHA256"))
-    Base64.getUrlEncoder.withoutPadding().encodeToString(mac.doFinal(message.getBytes("utf-8")))
   }
 
   def sign_HmacSHA256_base64_v0_5_2(message: String, secret: String): String = {


### PR DESCRIPTION
This PR fixes an issue with `RS256` JSON Web Signatures being encoded using `BASE64` encoder instead of `BASE64URL` one.
In order to prevent from similar mistakes in future, I extracted a protected `encode` method into `JwsAlgorithm` trait.