### PR TITLE
Fix CSRF protection bypass #74

### DIFF
--- a/core/src/main/scala/com/softwaremill/session/CsrfDirectives.scala
+++ b/core/src/main/scala/com/softwaremill/session/CsrfDirectives.scala
@@ -23,7 +23,7 @@ trait CsrfDirectives {
         // that the token matches.
         get.recover { _ =>
           submittedCsrfToken(checkMode).flatMap { submitted =>
-            if (submitted == cookie) {
+            if (submitted == cookie && !cookie.isEmpty) {
               pass
             } else {
               reject(checkMode.csrfManager.tokenInvalidRejection).toDirective[Unit]

--- a/core/src/test/scala/com/softwaremill/session/CsrfDirectivesTest.scala
+++ b/core/src/test/scala/com/softwaremill/session/CsrfDirectivesTest.scala
@@ -81,6 +81,20 @@ class CsrfDirectivesTest extends FlatSpec with ScalatestRouteTest with Matchers 
     }
   }
 
+  it should "reject requests if the csrf cookie and the header are empty" in {
+    Get("/site") ~> routes ~> check {
+      responseAs[String] should be("ok")
+
+      Post("/transfer_money") ~>
+        addHeader(Cookie(cookieName, "")) ~>
+        addHeader(sessionConfig.csrfSubmittedName, "") ~>
+        routes ~>
+        check {
+          rejections should be(List(AuthorizationFailedRejection))
+        }
+    }
+  }
+
   it should "accept requests if the csrf cookie matches the header value" in {
     Get("/site") ~> routes ~> check {
       responseAs[String] should be("ok")

--- a/javaTests/src/test/java/com/softwaremill/session/javadsl/CsrfDirectivesTest.java
+++ b/javaTests/src/test/java/com/softwaremill/session/javadsl/CsrfDirectivesTest.java
@@ -136,6 +136,33 @@ public class CsrfDirectivesTest extends HttpSessionAwareDirectivesTest {
     }
 
     @Test
+    public void shouldRejectRequestsIfTheCsrfCookieAndTheHeaderAreEmpty() {
+        // given
+        final Route route = createCsrfRouteWithCheckHeaderMode();
+
+        // when
+        TestRouteResult testRouteResult = testRoute(route)
+          .run(HttpRequest.GET("/site"));
+
+        // then
+        testRouteResult
+          .assertStatusCode(StatusCodes.OK);
+
+        /* second request */
+        // when
+        TestRouteResult testRouteResult2 = testRoute(route)
+          .run(HttpRequest.POST("/transfer_money")
+            .addHeader(Cookie.create(csrfCookieName, ""))
+            .addHeader(RawHeader.create(csrfSubmittedName, ""))
+          );
+
+        // then
+        testRouteResult2
+          .assertStatusCode(StatusCodes.FORBIDDEN);
+
+    }
+
+    @Test
     public void shouldAcceptRequestsIfTheCsrfCookieMatchesTheHeaderValue() {
         // given
         final Route route = createCsrfRouteWithCheckHeaderMode();


### PR DESCRIPTION
When passing an empty cookie together with an empty header value, the request is passed:
```
$ curl -i -X POST --cookie "_sessiondata=80549F21173A678C4C8D52871336E393A509CDAD-1583935580431-xmy_login;XSRF-TOKEN=" -H "X-XSRF-TOKEN;" http://localhost:8080/api/do_logout
HTTP/1.1 200 OK
Set-Cookie: _sessiondata=deleted; Expires=Wed, 01 Jan 1800 00:00:00 GMT; Path=/; HttpOnly
Server: akka-http/10.0.9
Date: Wed, 11 Mar 2020 13:57:35 GMT
Content-Type: text/plain; charset=UTF-8
Content-Length: 2

ok
```

This fix rejects such a request:

```
$ curl -i -X POST --cookie "_sessiondata=7D5834D6A017BE6A0578607136E09EC847981152-1583946346774-xmy_login;XSRF-TOKEN=" -H "X-XSRF-TOKEN;" http://localhost:8080/api/do_logout
HTTP/1.1 403 Forbidden
Server: akka-http/10.1.8
Date: Wed, 11 Mar 2020 16:56:09 GMT
Content-Type: text/plain; charset=UTF-8
Content-Length: 69

The supplied authentication is not authorized to access this resource
```