### PR TITLE
Fix bad call to deprecated copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+.bsp/
 
 # Scala-IDE specific
 .scala_dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: scala
 jdk:
-- oraclejdk8
+- oraclejdk11
 scala:
-- 2.11.12
 - 2.12.8
 - 2.13.0
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 jdk:
 - oraclejdk11
 scala:
-- 2.12.8
-- 2.13.0
+- 2.12.12
+- 2.13.4
 script:
    - sbt ++$TRAVIS_SCALA_VERSION test

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,16 @@
 lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   organization := "com.softwaremill.akka-http-session",
-  scalaVersion := "2.12.8",
-  crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.13.0")
+  scalaVersion := "2.12.12",
+  crossScalaVersions := Seq(scalaVersion.value, "2.13.4")
 )
 
-val akkaHttpVersion = "10.1.8"
-val akkaStreamsVersion = "2.5.23"
-val json4sVersion = "3.6.6"
+val akkaHttpVersion = "10.2.1"
+val akkaStreamsVersion = "2.6.10"
+val json4sVersion = "3.6.10"
 val akkaStreamsProvided = "com.typesafe.akka" %% "akka-stream" % akkaStreamsVersion % "provided"
 val akkaStreamsTestkit = "com.typesafe.akka" %% "akka-stream-testkit" % akkaStreamsVersion % "test"
 
-val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.2.3" % "test"
 
 lazy val rootProject = (project in file("."))
   .settings(commonSettings: _*)
@@ -26,7 +26,7 @@ lazy val core: Project = (project in file("core"))
       akkaStreamsProvided,
       "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % "test",
       akkaStreamsTestkit,
-      "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
+      "org.scalacheck" %% "scalacheck" % "1.15.1" % "test",
       scalaTest
     )
   )
@@ -72,7 +72,7 @@ lazy val javaTests: Project = (project in file("javaTests"))
       "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
       "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % "test",
       akkaStreamsTestkit,
-      "junit" % "junit" % "4.12" % "test",
+      "junit" % "junit" % "4.13.1" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
       scalaTest
     )

--- a/core/src/main/scala/com/softwaremill/session/CsrfDirectives.scala
+++ b/core/src/main/scala/com/softwaremill/session/CsrfDirectives.scala
@@ -39,8 +39,7 @@ trait CsrfDirectives {
   def submittedCsrfToken[T](checkMode: CsrfCheckMode[T]): Directive1[String] = {
     headerValueByName(checkMode.manager.config.csrfSubmittedName).recover { rejections =>
       checkMode match {
-        case c: CheckHeaderAndForm[T] =>
-          import c.materializer
+        case _: CheckHeaderAndForm[T] =>
           formField(checkMode.manager.config.csrfSubmittedName)
         case _ => reject(rejections: _*)
       }
@@ -58,7 +57,7 @@ object CsrfDirectives extends CsrfDirectives
 
 sealed trait CsrfCheckMode[T] {
   def manager: SessionManager[T]
-  def csrfManager = manager.csrfManager
+  def csrfManager: CsrfManager[T] = manager.csrfManager
 }
 class CheckHeader[T] private[session] (implicit val manager: SessionManager[T]) extends CsrfCheckMode[T]
 class CheckHeaderAndForm[T] private[session] (implicit

--- a/core/src/main/scala/com/softwaremill/session/SessionDirectives.scala
+++ b/core/src/main/scala/com/softwaremill/session/SessionDirectives.scala
@@ -167,7 +167,7 @@ trait OneOffSessionDirectives {
           case Some(_) => respondWithHeader(sc.clientSessionManager.createHeaderWithValue(""))
         }
 
-      case Some(_) => deleteCookie(sc.clientSessionManager.createCookieWithValue("").copy(maxAge = None))
+      case Some(_) => deleteCookie(sc.clientSessionManager.createCookieWithValue(""))
     }
   }
 }
@@ -211,12 +211,11 @@ trait RefreshableSessionDirectives { this: OneOffSessionDirectives =>
   }
 
   private[session] def invalidateRefreshableSession[T](sc: Refreshable[T], st: GetSessionTransport): Directive0 = {
-    import sc.ec
     read(sc, st).flatMap {
       case None => pass
       case Some((v, setSt)) =>
         val deleteTokenOnClient = setSt match {
-          case CookieST => deleteCookie(sc.refreshTokenManager.createCookie("").copy(maxAge = None))
+          case CookieST => deleteCookie(sc.refreshTokenManager.createCookie("", maxAge = None))
           case HeaderST => respondWithHeader(sc.refreshTokenManager.createHeader(""))
         }
 
@@ -233,7 +232,7 @@ trait RefreshableSessionDirectives { this: OneOffSessionDirectives =>
       st match {
         // respondWithDefault* directives let us avoid header/cookie duplication when session has already been set because of refreshable sessions.
         case CookieST =>
-          val createCookie = newToken.map(sc.refreshTokenManager.createCookie)
+          val createCookie = newToken.map(sc.refreshTokenManager.createCookie(_))
           onSuccess(createCookie).flatMap(c => respondWithDefaultCookie(c))
         case HeaderST =>
           val createHeader = newToken.map(sc.refreshTokenManager.createHeader)

--- a/core/src/main/scala/com/softwaremill/session/SessionEncoder.scala
+++ b/core/src/main/scala/com/softwaremill/session/SessionEncoder.scala
@@ -39,7 +39,7 @@ class BasicSessionEncoder[T](implicit serializer: SessionSerializer[T, String]) 
 
   override def decode(s: String, config: SessionConfig) = {
     def extractExpiry(data: String): (Option[Long], String) = {
-      config.sessionMaxAgeSeconds.fold((Option.empty[Long], data)) { maxAge =>
+      config.sessionMaxAgeSeconds.fold((Option.empty[Long], data)) { _ =>
         val splitted = data.split("-", 2)
         (Some(splitted(0).toLong), splitted(1))
       }

--- a/core/src/main/scala/com/softwaremill/session/SessionManager.scala
+++ b/core/src/main/scala/com/softwaremill/session/SessionManager.scala
@@ -139,12 +139,12 @@ trait RefreshTokenManager[T] {
     storeFuture
   }
 
-  def createCookie(value: String) =
+  def createCookie(value: String, maxAge: Option[Long] = Some(config.refreshTokenMaxAgeSeconds)) =
     HttpCookie(
       name = config.refreshTokenCookieConfig.name,
       value = value,
       expires = None,
-      maxAge = Some(config.refreshTokenMaxAgeSeconds),
+      maxAge = maxAge,
       domain = config.refreshTokenCookieConfig.domain,
       path = config.refreshTokenCookieConfig.path,
       secure = config.refreshTokenCookieConfig.secure,
@@ -174,7 +174,7 @@ trait RefreshTokenManager[T] {
     }
   }
 
-  def removeToken(value: String)(implicit ec: ExecutionContext): Future[Unit] = {
+  def removeToken(value: String): Future[Unit] = {
     decodeSelectorAndToken(value) match {
       case Some((s, _)) => storage.remove(s)
       case None         => Future.successful(())

--- a/core/src/test/scala/com/softwaremill/session/CsrfDirectivesTest.scala
+++ b/core/src/test/scala/com/softwaremill/session/CsrfDirectivesTest.scala
@@ -7,9 +7,11 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.softwaremill.session.CsrfDirectives._
 import com.softwaremill.session.CsrfOptions._
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest._
+import matchers.should._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class CsrfDirectivesTest extends FlatSpec with ScalatestRouteTest with Matchers {
+class CsrfDirectivesTest extends AnyFlatSpec with ScalatestRouteTest with Matchers {
 
   import TestData._
   val cookieName = sessionConfig.csrfCookieConfig.name

--- a/core/src/test/scala/com/softwaremill/session/OneOffSetRefreshableGetTest.scala
+++ b/core/src/test/scala/com/softwaremill/session/OneOffSetRefreshableGetTest.scala
@@ -4,9 +4,11 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.softwaremill.session.SessionDirectives._
 import com.softwaremill.session.SessionOptions._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest._
+import matchers.should._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class OneOffSetRefreshableGetTest extends FlatSpec with ScalatestRouteTest with Matchers with MultipleTransportTest {
+class OneOffSetRefreshableGetTest extends AnyFlatSpec with ScalatestRouteTest with Matchers with MultipleTransportTest {
 
   import TestData._
 

--- a/core/src/test/scala/com/softwaremill/session/OneOffTest.scala
+++ b/core/src/test/scala/com/softwaremill/session/OneOffTest.scala
@@ -6,9 +6,11 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.softwaremill.session.SessionDirectives._
 import com.softwaremill.session.SessionOptions._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest._
+import matchers.should._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class OneOffTest extends FlatSpec with ScalatestRouteTest with Matchers with MultipleTransportTest {
+class OneOffTest extends AnyFlatSpec with ScalatestRouteTest with Matchers with MultipleTransportTest {
 
   import TestData._
 

--- a/core/src/test/scala/com/softwaremill/session/RefreshableTest.scala
+++ b/core/src/test/scala/com/softwaremill/session/RefreshableTest.scala
@@ -5,9 +5,11 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.softwaremill.session.SessionDirectives._
 import com.softwaremill.session.SessionOptions._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest._
+import matchers.should._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class RefreshableTest extends FlatSpec with ScalatestRouteTest with Matchers with MultipleTransportTest {
+class RefreshableTest extends AnyFlatSpec with ScalatestRouteTest with Matchers with MultipleTransportTest {
 
   import TestData._
 

--- a/core/src/test/scala/com/softwaremill/session/SessionConfigTest.scala
+++ b/core/src/test/scala/com/softwaremill/session/SessionConfigTest.scala
@@ -6,11 +6,13 @@ import java.util.Base64
 import com.softwaremill.session.JwsAlgorithm.HmacSHA256
 import com.typesafe.config.ConfigValueFactory.fromAnyRef
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest._
+import matchers.should._
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
 
-class SessionConfigTest extends FlatSpec with Matchers with OptionValues {
+class SessionConfigTest extends AnyFlatSpec with Matchers with OptionValues {
 
   val fakeServerSecret = s"f4k3S3rv3rS3cr37-${"x" * 64}"
 

--- a/javaTests/src/test/java/com/softwaremill/session/javadsl/RefreshableTest.java
+++ b/javaTests/src/test/java/com/softwaremill/session/javadsl/RefreshableTest.java
@@ -777,7 +777,7 @@ public class RefreshableTest extends HttpSessionAwareDirectivesTest {
 
         // then
         fullResult.assertStatusCode(StatusCodes.OK);
-        fullResult.assertEntity("Corrupt(java.lang.ArrayIndexOutOfBoundsException: 1)");
+        fullResult.assertEntity("Corrupt(java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1)");
     }
 
     @Test

--- a/jwt/src/test/scala/com/softwaremill/session/SessionManagerJwtEncoderTest.scala
+++ b/jwt/src/test/scala/com/softwaremill/session/SessionManagerJwtEncoderTest.scala
@@ -8,11 +8,13 @@ import com.softwaremill.session.SessionConfig.{JwsConfig, JwtConfig}
 import org.json4s.JsonAST.{JObject, JString}
 import org.json4s.{JValue, _}
 import org.json4s.jackson.JsonMethods.parse
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest._
+import matchers.should._
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration._
 
-class SessionManagerJwtEncoderTest extends FlatSpec with Matchers {
+class SessionManagerJwtEncoderTest extends AnyFlatSpec with Matchers {
   val defaultConfig = SessionConfig.default("1234567890123456789012345678901234567890123456789012345678901234567890")
   val configMaxAge = defaultConfig.copy(jwt = defaultConfig.jwt.copy(expirationTimeout = Some(3600)))
   val configEncrypted = defaultConfig.copy(sessionEncryptData = true)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
-addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill" % "1.7.0")
+addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-common" % "1.9.14")
+addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-publish" % "1.9.14")
+addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-extra" % "1.9.14")


### PR DESCRIPTION
Full tech refresh, necessitated removal of scala 2.11 (not supported by the latest akka anymore, and hey, it's now over 6 years old!).
The push for this was to stop using HttpCookie::copy since it's deprecated (and there's a bug in the 20.2.x version anyway for that method), but one thing led to another and a full refresh is just sometimes easier.
 