### PR TITLE
hmac encoded csrf token

### DIFF
--- a/core/src/main/java/com/softwaremill/session/javadsl/CsrfDirectives.scala
+++ b/core/src/main/java/com/softwaremill/session/javadsl/CsrfDirectives.scala
@@ -12,7 +12,7 @@ import com.softwaremill.session.CsrfCheckMode
 trait CsrfDirectives {
 
   def randomTokenCsrfProtection[T](checkMode: CsrfCheckMode[T], inner: Supplier[Route]): Route = RouteAdapter {
-    com.softwaremill.session.CsrfDirectives.randomTokenCsrfProtection(checkMode) {
+    com.softwaremill.session.CsrfDirectives.hmacTokenCsrfProtection(checkMode) {
       inner.get.asInstanceOf[RouteAdapter].delegate
     }
   }

--- a/core/src/main/java/com/softwaremill/session/javadsl/CsrfDirectives.scala
+++ b/core/src/main/java/com/softwaremill/session/javadsl/CsrfDirectives.scala
@@ -11,11 +11,17 @@ import com.softwaremill.session.CsrfCheckMode
  */
 trait CsrfDirectives {
 
-  def randomTokenCsrfProtection[T](checkMode: CsrfCheckMode[T], inner: Supplier[Route]): Route = RouteAdapter {
+  def hmacTokenCsrfProtection[T](checkMode: CsrfCheckMode[T], inner: Supplier[Route]): Route = RouteAdapter {
     com.softwaremill.session.CsrfDirectives.hmacTokenCsrfProtection(checkMode) {
       inner.get.asInstanceOf[RouteAdapter].delegate
     }
   }
+
+  /**
+    * @deprecated as of release 0.6.1, replaced by {@link #hmacTokensCsrfProtection()}
+    */
+  def randomTokenCsrfProtection[T](checkMode: CsrfCheckMode[T], inner: Supplier[Route]): Route =
+    hmacTokenCsrfProtection(checkMode, inner)
 
   def setNewCsrfToken[T](checkMode: CsrfCheckMode[T], inner: Supplier[Route]): Route = RouteAdapter {
     com.softwaremill.session.CsrfDirectives.setNewCsrfToken(checkMode) {

--- a/core/src/main/scala/com/softwaremill/session/CsrfDirectives.scala
+++ b/core/src/main/scala/com/softwaremill/session/CsrfDirectives.scala
@@ -1,7 +1,7 @@
 package com.softwaremill.session
 
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.{Directive0, Directive1}
+import akka.http.scaladsl.server.{ Directive0, Directive1 }
 import akka.stream.Materializer
 
 trait CsrfDirectives {
@@ -14,16 +14,20 @@ trait CsrfDirectives {
     * Note that this scheme can be broken when not all subdomains are protected or not using HTTPS and secure cookies,
     * and the token is placed in the request body (not in the header).
     *
+    * The risk of the previous disclaimer is mitigated by using a concatenation of a timestamp and its HMAC hash
+    * as token value. During token validation, additional to checking that the cookie value and header/requestbody
+    * values are non-empty and equal, the hash of the timestamp is verified too.
+    *
     * See the documentation for more details.
     */
-  def randomTokenCsrfProtection[T](checkMode: CsrfCheckMode[T]): Directive0 = {
+  def hmacTokenCsrfProtection[T](checkMode: CsrfCheckMode[T]): Directive0 = {
     csrfTokenFromCookie(checkMode).flatMap {
       case Some(cookie) =>
         // if a cookie is already set, we let through all get requests (without setting a new token), or validate
         // that the token matches.
         get.recover { _ =>
           submittedCsrfToken(checkMode).flatMap { submitted =>
-            if (submitted == cookie && !cookie.isEmpty) {
+            if (submitted == cookie && !cookie.isEmpty && checkMode.csrfManager.validateToken(cookie)) {
               pass
             } else {
               reject(checkMode.csrfManager.tokenInvalidRejection).toDirective[Unit]
@@ -35,6 +39,9 @@ trait CsrfDirectives {
         (get & setNewCsrfToken(checkMode)).recover(_ => reject(checkMode.csrfManager.tokenInvalidRejection))
     }
   }
+
+  // for backward compatibility
+  def randomTokenCsrfProtection[T](checkMode: CsrfCheckMode[T]): Directive0 = hmacTokenCsrfProtection(checkMode)
 
   def submittedCsrfToken[T](checkMode: CsrfCheckMode[T]): Directive1[String] = {
     headerValueByName(checkMode.manager.config.csrfSubmittedName).recover { rejections =>

--- a/core/src/main/scala/com/softwaremill/session/CsrfDirectives.scala
+++ b/core/src/main/scala/com/softwaremill/session/CsrfDirectives.scala
@@ -11,12 +11,12 @@ trait CsrfDirectives {
     * doesn't have the token set in the header. For all other requests, the value of the token from the CSRF cookie must
     * match the value in the custom header (or request body, if `checkFormBody` is `true`).
     *
+    * The cookie value is the concatenation of a timestamp and its HMAC hash following the OWASP recommendation for
+    * CSRF prevention:
+    * @see <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#hmac-based-token-pattern">OWASP</a>
+    *
     * Note that this scheme can be broken when not all subdomains are protected or not using HTTPS and secure cookies,
     * and the token is placed in the request body (not in the header).
-    *
-    * The risk of the previous disclaimer is mitigated by using a concatenation of a timestamp and its HMAC hash
-    * as token value. During token validation, additional to checking that the cookie value and header/requestbody
-    * values are non-empty and equal, the hash of the timestamp is verified too.
     *
     * See the documentation for more details.
     */
@@ -40,7 +40,7 @@ trait CsrfDirectives {
     }
   }
 
-  // for backward compatibility
+  @deprecated("use hmacTokenCsrfProtection", "0.6.1")
   def randomTokenCsrfProtection[T](checkMode: CsrfCheckMode[T]): Directive0 = hmacTokenCsrfProtection(checkMode)
 
   def submittedCsrfToken[T](checkMode: CsrfCheckMode[T]): Directive1[String] = {

--- a/example/src/main/scala/com/softwaremill/example/ScalaExample.scala
+++ b/example/src/main/scala/com/softwaremill/example/ScalaExample.scala
@@ -37,7 +37,7 @@ object Example extends App with StrictLogging {
     path("") {
       redirect("/site/index.html", Found)
     } ~
-      randomTokenCsrfProtection(checkHeader) {
+      hmacTokenCsrfProtection(checkHeader) {
         pathPrefix("api") {
           path("do_login") {
             post {

--- a/example/src/main/scala/com/softwaremill/example/session/SetSessionScala.scala
+++ b/example/src/main/scala/com/softwaremill/example/session/SetSessionScala.scala
@@ -32,7 +32,7 @@ object SetSessionScala extends App with StrictLogging {
   val myInvalidateSession = invalidateSession(refreshable, usingCookies)
 
   val routes =
-    randomTokenCsrfProtection(checkHeader) {
+    hmacTokenCsrfProtection(checkHeader) {
       pathPrefix("api") {
         path("do_login") {
           post {


### PR DESCRIPTION
Hi, this is a first iteration of a PR to resolve issue #77 
I have provided a minimal implementation and am open to suggestions for improvement. For example, I decided to reuse the existing server secret to hash the timestamp, instead of defining a second server secret for this new purpose (personally I think it can do no harm to reuse the same server secret, but feel free to disagree, in which case we'll have to add config changes for an additional server secret).
Best,
Willem